### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 </body>
 <footer>
 
-    <div>Made with Github Pages</div>
+    <div>Made with **GitHub** Pages</div>
 
 </footer>
 </html>


### PR DESCRIPTION
## Summary
- correct GitHub capitalization in footer text

## Testing
- `grep -n "Made with" index.html`


------
https://chatgpt.com/codex/tasks/task_e_6870dde4d3a8832798cd8573da794fcf