### PR TITLE
Move closing body tag under footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,8 @@
     <div class="item1"><a href="http://endless.horse/" style="color: white; text-decoration: none;">Endless Horse</a></div>
     <div class="item">Currently employed at:<br><br> Bechtle AG <br><br> as a IT specialist data and process analysis</div>
 </div>
-
-
-</body>
 <footer>
-
-    <div>Made with Github Pages</div>
-
+    <div>Made with GitHub Pages</div>
 </footer>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the footer is inside the body by relocating the closing tag
- fix casing on the "GitHub" footer text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6870ddfa84908327b3cc400d7511c3a4